### PR TITLE
fix metronome toggle

### DIFF
--- a/internal/shifts/recordshift.py
+++ b/internal/shifts/recordshift.py
@@ -46,7 +46,7 @@ class RecordShift(ShiftState):
             if command.is_lift:
                 coord = command.getPadCoord()
                 if coord == (0, 0):
-                    beat.toggleMetronome()
+                    transport.globalTransport(eventconsts.midi.FPT_Metronome, True)
                     command.handle("Toggled metronome")
                     self.use()
                     


### PR DESCRIPTION
Script crashed when I tried to toggle the metronome. According to https://www.image-line.com/fl-studio-learning/fl-studio-online-manual/html/midi_scripting.htm, it's sent as a global transport command, whatever that is. This fixed it for me.